### PR TITLE
[feat] add logger for observability

### DIFF
--- a/actions/logging/index.ts
+++ b/actions/logging/index.ts
@@ -1,0 +1,18 @@
+import { serverError, serverLog, serverWarn } from './wrappers';
+
+// create logger class for abstraction
+class Logger {
+  static async log(message?: unknown, ...optionalParams: unknown[]) {
+    await serverLog(message, ...optionalParams);
+  }
+
+  static async warn(message?: unknown, ...optionalParams: unknown[]) {
+    await serverWarn(message, ...optionalParams);
+  }
+
+  static async error(message?: unknown, ...optionalParams: unknown[]) {
+    await serverError(message, ...optionalParams);
+  }
+}
+
+export default Logger;

--- a/actions/logging/index.ts
+++ b/actions/logging/index.ts
@@ -1,17 +1,21 @@
-import { serverError, serverLog, serverWarn } from './wrappers';
+import { serverError, serverInfo, serverLog, serverWarn } from './wrappers';
 
 // create logger class for abstraction
 class Logger {
-  static async log(message?: unknown, ...optionalParams: unknown[]) {
-    await serverLog(message, ...optionalParams);
+  static async log(message: string) {
+    await serverLog(message);
   }
 
-  static async warn(message?: unknown, ...optionalParams: unknown[]) {
-    await serverWarn(message, ...optionalParams);
+  static async warn(message: string) {
+    await serverWarn(message);
   }
 
-  static async error(message?: unknown, ...optionalParams: unknown[]) {
-    await serverError(message, ...optionalParams);
+  static async error(message: string) {
+    await serverError(message);
+  }
+
+  static async info(message: string) {
+    await serverInfo(message);
   }
 }
 

--- a/actions/logging/wrappers.ts
+++ b/actions/logging/wrappers.ts
@@ -13,23 +13,18 @@
  * client-side code.
  */
 
-export async function serverLog(
-  message?: unknown,
-  ...optionalParams: unknown[]
-) {
-  console.log(message, ...optionalParams);
+export async function serverLog(message: string) {
+  console.log(message);
 }
 
-export async function serverWarn(
-  message?: unknown,
-  ...optionalParams: unknown[]
-) {
-  console.warn(message, ...optionalParams);
+export async function serverWarn(message: string) {
+  console.warn(message);
 }
 
-export async function serverError(
-  message?: unknown,
-  ...optionalParams: unknown[]
-) {
-  console.error(message, ...optionalParams);
+export async function serverError(message: string) {
+  console.error(message);
+}
+
+export async function serverInfo(message: string) {
+  console.info(message);
 }

--- a/actions/logging/wrappers.ts
+++ b/actions/logging/wrappers.ts
@@ -1,0 +1,35 @@
+'use server';
+
+/**
+ * This file defines server actions for logging.
+ * The output of these logs will be shown only to
+ * the server console, with the possibility of extending
+ * to external logging services in the future.
+ *
+ * This wrapping is necessary because server actions must be
+ * defined as async free functions (i.e. not class methods).
+ * However, the functions defined here are used directly by
+ * the Logger class, accessible to both server-side and
+ * client-side code.
+ */
+
+export async function serverLog(
+  message?: unknown,
+  ...optionalParams: unknown[]
+) {
+  console.log(message, ...optionalParams);
+}
+
+export async function serverWarn(
+  message?: unknown,
+  ...optionalParams: unknown[]
+) {
+  console.warn(message, ...optionalParams);
+}
+
+export async function serverError(
+  message?: unknown,
+  ...optionalParams: unknown[]
+) {
+  console.error(message, ...optionalParams);
+}


### PR DESCRIPTION
[//]: # "Feel free to customize this template and the emojis to your project's vibes"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

- Added a Logger object to log messages on the server-side console


## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

Test that calls of `Logger` methods in the client side (e.g. in a file with `'use client'` directive) creates a message on the server console, and nothing is outputted in the browser console.

## Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."

Once deployed, the logs outputted by this system will show up on Vercel's log console. The unfortunate caveat of hosting on Vercel (with free plan) is the limit of 3 day retention of logs. As such, if longer log retention is desired, we should aim to place our logs on an external service (e.g. [Grafana](https://grafana.com/), [Apache Spark](https://spark.apache.org/)). It should be a simple drop-in replacement of `console.*` functions with the relevant API calls.


CC: @ethan-tam33