### PR TITLE
[bug] use production url instead of site url

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -42,7 +42,7 @@ export const getSiteUrl = () => {
   // environment variables set by Vercel when deployed
   // if they don't exist, assume local testing environment
   let url =
-    process?.env?.NEXT_PUBLIC_SITE_URL ??
+    process?.env?.NEXT_PUBLIC_PRODUCTION_URL ??
     process?.env?.NEXT_PUBLIC_VERCEL_URL ??
     'http://localhost:3000/';
 


### PR DESCRIPTION
[//]: # "Feel free to customize this template and the emojis to your project's vibes"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

- Attempts to fix a bug where reset password flow redirects to private site instead of production site

## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

Test the reset password flow in the preview deployment. Using production site system variable should make it use the production site (`adopt-an-inmate.vercel.app`) over the private deployment-specific site


CC: @ethan-tam33