### PR TITLE
[fix] refine site url determination logic

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -39,7 +39,7 @@ export function cn(...inputs: ClassValue[]) {
  * Returns the site URL depending on environment.
  */
 export const getSiteUrl = () => {
-  const deployEnv = process.env.VERCEL_ENV;
+  const deployEnv = process.env.NEXT_PUBLIC_VERCEL_ENV;
 
   // no vercel env => local environment, use localhost
   if (!deployEnv) return 'http://localhost:3000/';
@@ -48,8 +48,8 @@ export const getSiteUrl = () => {
   // otherwise, use prod site url
   const siteUrl =
     deployEnv === 'preview'
-      ? process.env.VERCEL_URL
-      : process.env.VERCEL_PROJECT_PRODUCTION_URL;
+      ? process.env.NEXT_PUBLIC_VERCEL_URL
+      : process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL;
 
   return `https://${siteUrl}/`;
 };


### PR DESCRIPTION
[//]: # "Feel free to customize this template and the emojis to your project's vibes"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

- Refine the logic that determines the current site URL depending on the deployment environment
- This fix should fix issues with the reset password link leading to a private preview URL

## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

The nature of the feature requires testing after production. The site URL is determined as "http://localhost:3000/" if it detects it is not deployed by Vercel. If it is deployed in a preview environment by Vercel, the site URL will be the preview URL. If it is deployed in production, it will use the production URL.

For a complete test, the forgot password email link should be tested after this PR is merged.


## Relevant links
[//]: # 'Copy links to any tutorials or documentation that was useful to you when working on this PR'

- [Vercel's system environment variables](https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_URL)



CC: @ethan-tam33