### PR TITLE
[feat] update adoptee monday status

### DIFF
--- a/actions/emails/email.ts
+++ b/actions/emails/email.ts
@@ -1,17 +1,24 @@
 import nodemailer from 'nodemailer';
 
 export async function autoEmailSender(
-  senderAddress: string,
-  senderAppPassword: string,
-  senderName: string,
   text: string,
   subject: string,
   recipient: string,
 ) {
+  const senderAddress = process.env.BREVO_SMTP_USER;
+  const senderAppPassword = process.env.BREVO_SMTP_KEY;
+  const senderName = process.env.EMAIL_SENDER_NAME ?? 'Adopt an Inmate Team';
+
+  if (!senderAddress || !senderAppPassword) {
+    throw new Error(
+      'Missing email configuration: BREVO_SMTP_USER and BREVO_SMTP_KEY must be set',
+    );
+  }
+
   const transporter = nodemailer.createTransport({
-    secure: true,
-    host: 'smtp.gmail.com',
-    port: 465,
+    host: 'smtp-relay.brevo.com',
+    port: 587,
+    secure: false,
     auth: {
       user: senderAddress,
       pass: senderAppPassword,
@@ -21,8 +28,8 @@ export async function autoEmailSender(
   await transporter.sendMail({
     from: `${senderName} <${senderAddress}>`,
     to: recipient,
-    subject: subject,
-    text: text,
+    subject,
+    text,
   });
 }
 

--- a/actions/monday/mutation.ts
+++ b/actions/monday/mutation.ts
@@ -21,6 +21,7 @@ export const createRow = async (profile: Profile) => {
     state: 'location_mkxage9t',
     veteran_status: 'dropdown_mkxa18jg',
     user_id: '', // blank on purpose
+    monday_id: '', // not sent to this board
   };
 
   // process veteran status from boolean to "yes" or "no"

--- a/actions/monday/mutations/changeStatus.ts
+++ b/actions/monday/mutations/changeStatus.ts
@@ -53,7 +53,11 @@ export async function updateAdopteeMondayStatus(
   const boardId = getEnvVar('MONDAY_WL_PIPS_BOARD_ID');
 
   if (status === 'OFC') {
-    return buildStatusUpdateMutationInner(boardId, mondayItemIds, () => LABEL_OFC);
+    return buildStatusUpdateMutationInner(
+      boardId,
+      mondayItemIds,
+      () => LABEL_OFC,
+    );
   }
 
   const supabase = await getSupabaseServerClient();

--- a/actions/monday/mutations/changeStatus.ts
+++ b/actions/monday/mutations/changeStatus.ts
@@ -1,0 +1,82 @@
+'use server';
+
+import { getSupabaseServerClient } from '@/lib/supabase';
+import { getEnvVar } from '@/lib/utils';
+import { mondayApiClient } from '../core';
+
+/** Short codes for adoptee status on the WL PIPs Monday board (column status__1). */
+export type AdopteeMondayStatusCode = 'WL' | 'OFC';
+
+const LABEL_WL = 'WL: Wait Listed';
+const LABEL_WLFA = 'WLFA: Wait Listed Formerly Adopted';
+const LABEL_OFC = 'OFC: Out for Consideration';
+
+/**
+ * Builds the inner body of a Monday `mutation { ... }` that updates status__1
+ * for each item (comma-separated `change_simple_column_value` operations).
+ */
+function buildStatusUpdateMutationInner(
+  boardId: string,
+  mondayItemIds: string[],
+  labelForIndex: (itemId: string, index: number) => string,
+): string {
+  return mondayItemIds
+    .map(
+      (id, idx) =>
+        `update${idx + 1}:change_simple_column_value(
+          board_id: "${boardId}",
+          item_id: "${id}",
+          column_id: "status__1",
+          value: "${labelForIndex(id, idx).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"
+        ) { id }`,
+    )
+    .join(',');
+}
+
+/**
+ * Updates adoptee rows on the WL PIPs board (column `status__1`).
+ *
+ * - **OFC**: Returns only the comma-separated mutation body (no `mutation` wrapper) so it can be
+ *   composed into a larger mutation (e.g. with `create_subitem`). Does not execute the API call.
+ * - **WL**: Loads `formerly_adopted` from `adoptee_vector_test` for each id, sets Monday to
+ *   `WLFA: Wait Listed Formerly Adopted` or `WL: Wait Listed` accordingly, executes the mutation,
+ *   and returns the full `mutation { ... }` string (callers typically ignore it).
+ */
+export async function updateAdopteeMondayStatus(
+  mondayItemIds: string[],
+  status: AdopteeMondayStatusCode,
+): Promise<string> {
+  if (mondayItemIds.length === 0) {
+    return '';
+  }
+
+  const boardId = getEnvVar('MONDAY_WL_PIPS_BOARD_ID');
+
+  if (status === 'OFC') {
+    return buildStatusUpdateMutationInner(boardId, mondayItemIds, () => LABEL_OFC);
+  }
+
+  const supabase = await getSupabaseServerClient();
+  const { data: rows, error } = await supabase
+    .from('adoptee_vector_test')
+    .select('id, formerly_adopted')
+    .in('id', mondayItemIds);
+
+  if (error) {
+    throw new Error(
+      `updateAdopteeMondayStatus (WL): failed to load formerly_adopted: ${error.message}`,
+    );
+  }
+
+  const formerlyById = new Map(
+    (rows ?? []).map(r => [r.id, Boolean(r.formerly_adopted)]),
+  );
+
+  const inner = buildStatusUpdateMutationInner(boardId, mondayItemIds, id =>
+    formerlyById.get(id) ? LABEL_WLFA : LABEL_WL,
+  );
+
+  const fullMutation = `mutation { ${inner} }`;
+  await mondayApiClient.request(fullMutation);
+  return fullMutation;
+}

--- a/actions/monday/mutations/exportApplication.ts
+++ b/actions/monday/mutations/exportApplication.ts
@@ -1,0 +1,395 @@
+'use server';
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import Logger from '@/actions/logging';
+import { CONFIG } from '@/config';
+import { capitalize } from '@/lib/formatters';
+import { getSupabaseServerClient } from '@/lib/supabase';
+import { dangerous_getSupabaseServiceClient } from '@/lib/supabase/service';
+import { assert, getEnvVar } from '@/lib/utils';
+import { ProfileAndApplication } from '@/types/schema';
+import { mondayApiClient } from '../core';
+import { updateAdopteeMondayStatus } from './changeStatus';
+
+// get env var and assert it exists at system level to trigger
+// error messages at build time (rather than run time)
+// => alert us to setup these env vars before the function needs them
+const MONDAY_ADOPTER_DATA_BOARD_ID = getEnvVar('MONDAY_ADOPTER_DATA_BOARD_ID');
+const MONDAY_ADOPTER_DATA_WAITING_GROUP_ID = getEnvVar(
+  'MONDAY_ADOPTER_DATA_WAITING_GROUP_ID',
+);
+
+////
+// HELPER FUNCTION
+////
+
+/**
+ * Fetches relevant profile and application information
+ * given the appId and userId. Performs data validation.
+ * Returns { appData } if data is valid, otherwise
+ * { error } with an error message
+ */
+const getAppData = async (
+  supabase: SupabaseClient,
+  appId: string,
+  userId: string,
+) => {
+  // fetch app data from database
+  const { data: appDataList, error: rpcFuncError } = await supabase.rpc(
+    'get_user_and_application',
+    { app_id: appId },
+  );
+
+  // validate app data
+  let appData: ProfileAndApplication;
+  try {
+    assert(!rpcFuncError, {
+      sysErr: `Error trying to invoke get_user_and_application(${appId}): ${rpcFuncError?.message}`,
+      err: 'An unexpected error occurred.',
+    });
+
+    assert(!!appDataList && appDataList.length === 1, {
+      sysErr: `Could not find application with ID ${appId}`,
+      err: 'Could not find application.',
+    });
+
+    appData = appDataList![0];
+  } catch (err) {
+    const e = err as Record<string, string>;
+    Logger.error(e.sysErr);
+    return { error: e.sysErr };
+  }
+
+  // validate application
+  try {
+    assert(!appData.exported_to_monday, 'Application already exported.');
+    assert(userId === appData.user_id, 'User ID mismatch.');
+  } catch (error) {
+    return { error };
+  }
+
+  // verify data integrity of ranked cards object
+  try {
+    assert(!!appData.ranked_cards);
+    assert(appData.ranked_cards instanceof Array);
+    const rankedCardsArray = appData.ranked_cards as Array<string>;
+    assert(rankedCardsArray.length === 4);
+  } catch {
+    return { error: 'Invalid ranked cards object.' };
+  }
+
+  return { appData };
+};
+
+/**
+ * Parses a column values object based on the
+ * remapping of column names defined in the column mapping.
+ */
+const parseColumns = <K extends string>(
+  columnMapping: Record<K, string>,
+  columnValues: Partial<Record<K, unknown>>,
+) => {
+  return Object.entries(columnValues).reduce(
+    (agg: Record<string, unknown>, [key, val]) => {
+      const k = key as K;
+      agg[columnMapping[k]] = val;
+      return agg;
+    },
+    {},
+  );
+};
+
+/**
+ * Generate a mutation query to create the
+ * main item.
+ */
+const getQueryCreateMainItem = (
+  appData: ProfileAndApplication,
+  email: string,
+) => {
+  // define and compute column values
+  const currentTime = new Date();
+  const currentDateISOString = currentTime.toISOString().split('T')[0]; // ex: 2026-02-22
+  const capitalizedPronouns = appData.pronouns
+    .split('/')
+    .map(p => capitalize(p.trim()))
+    .join(' / ');
+
+  const mainItemColumnValues = parseColumns(
+    {
+      email: 'email__1',
+      added_time: 'date7',
+      first_name: 'text__1',
+      last_name: 'text5__1',
+      current_status: 'status4',
+      gender: 'label__1',
+      pronouns: 'single_select__1',
+      gender_preference: 'color__1',
+      date_of_birth: 'date',
+      location: 'location7',
+      notes: 'notes__1',
+      veteran_status: 'dropdown__1',
+    },
+    {
+      email: { email, text: email },
+      added_time: currentDateISOString,
+      current_status: 'Pending',
+      date_of_birth: appData.date_of_birth,
+      first_name: appData.first_name,
+      last_name: appData.last_name,
+      location: { lat: 0, lng: 0, address: appData.state },
+      pronouns: capitalizedPronouns,
+      veteran_status: appData.veteran_status ? 'Yes' : 'No',
+    },
+  );
+
+  const mainItemCreateQuery = `
+    mutation {
+      create_item(
+        board_id: "${MONDAY_ADOPTER_DATA_BOARD_ID}",
+        group_id: "${MONDAY_ADOPTER_DATA_WAITING_GROUP_ID}",
+        item_name: "${email}",
+        create_labels_if_missing: true,
+        column_values: "${JSON.stringify(mainItemColumnValues).replaceAll('"', '\\"')}"
+      ) {
+        id
+      }
+    }
+  `;
+
+  return mainItemCreateQuery;
+};
+
+/**
+ * Generate a query to create a subitem
+ * corresponding to the application,
+ * under the main item that corresponds
+ * to the adopter.
+ */
+const getQueryCreateSubItem = (
+  appData: ProfileAndApplication,
+  mainItemId: string,
+  adopteeData: {
+    id: string;
+    inmate_id: string;
+  }[],
+) => {
+  // get current time
+  const currentTime = new Date();
+  const currentDateISOString = currentTime.toISOString().split('T')[0];
+
+  // parse gender preference
+  const genderPrefMap = {
+    no_preference: 'None',
+    female: 'Female',
+    male: 'Male',
+  };
+
+  const parsedGenderPref = Object.keys(genderPrefMap).includes(
+    appData.gender_pref,
+  )
+    ? genderPrefMap[appData.gender_pref as keyof typeof genderPrefMap]
+    : 'Default';
+
+  // parse ranked cards
+  const adopteeMap = adopteeData.reduce(
+    (acc, cur) => {
+      acc[cur.id] = cur.inmate_id;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  const rankedCards = appData.ranked_cards as Array<string>;
+  const rankedCardsOrder = rankedCards.map(c => adopteeMap[c]).join(', ');
+
+  const subItemColumnValues = parseColumns(
+    {
+      status: 'status',
+      gender_preference: 'status2__1',
+      match_list_links: 'connect_boards1__1',
+      bio: 'long_text__1',
+      order: 'long_text5__1',
+      date_received: 'date__1',
+    },
+    {
+      status: 'Pending',
+      gender_preference: parsedGenderPref,
+      match_list_links: { item_ids: appData.ranked_cards },
+      bio: appData.personal_bio,
+      order: rankedCardsOrder,
+      date_received: currentDateISOString,
+    },
+  );
+
+  const subItemCreateQuery = `
+    create_subitem(
+      parent_item_id: "${mainItemId}",
+      item_name: "Request",
+      column_values: "${JSON.stringify(subItemColumnValues).replaceAll('"', '\\"')}"
+    ) {
+      id  
+    }
+  `;
+
+  return subItemCreateQuery;
+};
+
+////
+// MAIN FUNCTION
+////
+
+const exportApplication = async (appId: string) => {
+  if (!CONFIG.enableMondayMutations)
+    return { success: false, error: 'Forbidden action.' };
+
+  const supabase = await getSupabaseServerClient();
+
+  // get logged in user
+  const {
+    data: { user },
+    error: getUserError,
+  } = await supabase.auth.getUser();
+
+  if (getUserError || !user) {
+    Logger.error(`Error trying to get user when exporting Monday application.`);
+    return { success: false, error: 'Failed to identify user.' };
+  }
+
+  // just a check to appease typescript bc email can technically be undefined
+  // shouldn't happen for us since we only have email login
+  if (!user.email) {
+    return { success: false, error: 'User has no email.' };
+  }
+
+  // fetch app data from database
+  const { appData, error: appDataError } = await getAppData(
+    supabase,
+    appId,
+    user.id,
+  );
+  if (!appData) return { success: false, error: appDataError };
+
+  // get relevant adoptee data
+  const { data: adopteeData, error: getAdopteeError } = await supabase
+    .from('adoptee_vector_test')
+    .select('id, inmate_id')
+    .in('id', appData.ranked_cards as Array<string>);
+  if (getAdopteeError || !adopteeData || adopteeData.length !== 4) {
+    Logger.error(
+      `Error fetching adoptees for application ${appId}: ${getAdopteeError}`,
+    );
+    return { success: false, error: 'Failed to fetch adoptees.' };
+  }
+
+  // check if main item already exists on monday
+  let mainItemId = appData.adopter_monday_id;
+
+  // if main item doesn't exist, create it
+  if (!appData.adopter_monday_id) {
+    const createMainItemQuery = getQueryCreateMainItem(appData, user.email);
+
+    const response = await mondayApiClient.request(createMainItemQuery);
+
+    // interpret response, get main item id
+    try {
+      const resObj = response as Record<string, unknown>;
+      const createItemField = resObj.create_item as Record<string, string>;
+      mainItemId = createItemField.id;
+    } catch (err) {
+      Logger.error(
+        `Error parsing response when creating item in Monday: ${err}`,
+      );
+      return { success: false, error: 'An unexpected error occurred.' };
+    }
+
+    // update supabase with adopter's monday ID (main item ID)
+    const { error: updateError } = await supabase
+      .from('adopter_profiles')
+      .update({ monday_id: mainItemId })
+      .eq('user_id', user.id);
+
+    // highly unlikely
+    // would only error if the profile row is deleted
+    // or if the column was renamed/deleted
+    if (updateError) {
+      Logger.error(
+        `[CRITICAL] Error trying to update adopter profile for user ${user.email} (ID ${user.id}): ${updateError}`,
+      );
+      // NOTE: allow pass through, don't want to report unsuccessful just
+      // bc push to supabase fails. Should still aim to get data to Monday.
+      // Then, admins can at least have access to data present here.
+    }
+  }
+
+  if (!mainItemId) {
+    return { success: false, error: 'Missing adopter Monday item.' };
+  }
+
+  // execute remaining supplementary queries to:
+  // - create subitem, which corresponds with application
+  // - update adoptee status on Monday to OFC
+  const createSubitemQuery = getQueryCreateSubItem(
+    appData,
+    mainItemId,
+    adopteeData,
+  );
+  const updateAdopteesQuery = await updateAdopteeMondayStatus(
+    appData.ranked_cards as string[],
+    'OFC',
+  );
+
+  const supplementaryQuery = `
+    mutation {
+      ${createSubitemQuery},
+      ${updateAdopteesQuery}
+    }
+  `;
+
+  const response = await mondayApiClient.request(supplementaryQuery);
+
+  // interpret subitem id
+  let subitemId = '';
+  try {
+    const resObj = response as Record<string, unknown>;
+    const createSubitemField = resObj.create_subitem as Record<string, string>;
+    subitemId = createSubitemField.id;
+  } catch (err) {
+    Logger.error(`Error trying to interpret create_subitem response: ${err}`);
+    return { success: false, error: 'An unexpected error occurred.' };
+  }
+
+  // update application record on supabase
+  const { error: updateError } = await supabase
+    .from('adopter_applications_dummy')
+    .update({ exported_to_monday: true, monday_id: subitemId })
+    .eq('app_uuid', appId);
+
+  // highly unlikely
+  // would only error if app was deleted
+  // or columns were renamed/deleted
+  if (updateError) {
+    Logger.error(`[CRITICAL] Error trying to update ${appId}: ${updateError}`);
+    // NOTE: allow successful report to go through, since at least
+    // the data reached the admins. If the push fails once,
+    // chances are, it will fail again - the cause is likely permanent
+    // and should be critical cause to investigate.
+  }
+
+  // mark adoptees as OFC on Supabase
+  const supabaseService = await dangerous_getSupabaseServiceClient();
+  const { error: updateAdopteesError } = await supabaseService
+    .from('adoptee_vector_test')
+    .update({ status: 'OUT_FOR_CONSIDERATION' })
+    .in('id', appData.ranked_cards as Array<string>);
+
+  if (updateAdopteesError) {
+    Logger.error(
+      `[CRITICAL] Error trying to update adoptees for ${appId}: ${updateAdopteesError}`,
+    );
+  }
+
+  return { success: true };
+};
+
+export default exportApplication;

--- a/actions/monday/queryMatchedAdopteeForApprovedApplication.ts
+++ b/actions/monday/queryMatchedAdopteeForApprovedApplication.ts
@@ -1,0 +1,178 @@
+'use server';
+
+import { getSupabaseServerClient } from '@/lib/supabase';
+import { assertEnvVarExists } from '@/lib/utils';
+import { RankedAdopteeMatch } from '@/types/schema';
+import { mondayApiClient } from './core';
+
+export type MatchedAdopteeResult = {
+  matchedAdopteeId: string;
+  unmatchedAdopteeIds: string[];
+};
+
+function uniqueStrings(values: string[]) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+type MondayItem = {
+  id: string;
+  group?: {
+    title?: string | null;
+  } | null;
+};
+
+async function fetchCandidateIdsFromBoard(params: {
+  boardId: string;
+  candidateIds: Set<string>;
+  groupTitlePredicate: (groupTitle: string) => boolean;
+  maxFound: number;
+}) {
+  const { boardId, candidateIds, groupTitlePredicate, maxFound } = params;
+
+  const found = new Set<string>();
+  let cursor: string | null = null;
+
+  // Avoid infinite loops if Monday returns unexpected cursor behavior.
+  for (let page = 0; page < 50 && found.size < maxFound; page++) {
+    const cursorArg = cursor ? `cursor: "${cursor}"` : '';
+    const itemsPageArgs = cursorArg ? `limit: 100, ${cursorArg}` : 'limit: 100';
+
+    const gpl = `query {
+      boards(ids: ${boardId}) {
+        items_page(${itemsPageArgs}) {
+          cursor
+          items {
+            id
+            group { title }
+          }
+        }
+      }
+    }`;
+
+    const response = await mondayApiClient.request(gpl);
+
+    const responseObj = response as Record<string, unknown>;
+    const maybeData = 'data' in responseObj ? responseObj.data : responseObj;
+    const dataObj = maybeData as Record<string, unknown>;
+
+    const boardsMaybe = dataObj.boards;
+    const boardsArray = Array.isArray(boardsMaybe) ? boardsMaybe : [];
+    const firstBoard = boardsArray[0] as Record<string, unknown> | undefined;
+    const itemsPageMaybe = firstBoard?.['items_page'] as
+      | Record<string, unknown>
+      | undefined;
+
+    const itemsMaybe = itemsPageMaybe?.items;
+    const itemsArray = Array.isArray(itemsMaybe) ? itemsMaybe : [];
+
+    const items: MondayItem[] = itemsArray as MondayItem[];
+
+    for (const item of items) {
+      if (!candidateIds.has(String(item.id))) continue;
+
+      const groupTitle = item.group?.title ?? '';
+      if (!groupTitle) continue;
+
+      if (groupTitlePredicate(String(groupTitle))) {
+        found.add(String(item.id));
+        if (found.size >= maxFound) break;
+      }
+    }
+
+    const cursorMaybe = itemsPageMaybe?.['cursor'];
+    cursor = typeof cursorMaybe === 'string' ? cursorMaybe : null;
+    if (!cursor) break;
+  }
+
+  return found;
+}
+
+export async function queryMatchedAdopteeForApprovedApplication(
+  applicationId: string,
+): Promise<MatchedAdopteeResult> {
+  const wlBoardId = process.env.MONDAY_WL_PIPS_BOARD_ID ?? '';
+  const adoptedBoardId = process.env.MONDAY_ADOPTED_BOARD_ID ?? '';
+
+  assertEnvVarExists('MONDAY_WL_PIPS_BOARD_ID');
+  assertEnvVarExists('MONDAY_ADOPTED_BOARD_ID');
+
+  const supabase = await getSupabaseServerClient();
+  const { data: appData, error } = await supabase
+    .from('adopter_applications_dummy')
+    .select('ranked_cards')
+    .eq('app_uuid', applicationId)
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to fetch ranked_cards: ${error.message}`);
+  if (!appData)
+    throw new Error(`Application not found for app_uuid=${applicationId}`);
+
+  const rankedCards = appData.ranked_cards as RankedAdopteeMatch[] | null;
+  if (!rankedCards || !Array.isArray(rankedCards) || rankedCards.length !== 4) {
+    throw new Error(
+      `Expected ranked_cards to contain exactly 4 adoptee ids for app_uuid=${applicationId}`,
+    );
+  }
+
+  // ranked_cards.id stores the Monday item id (as per testing guidance).
+  const candidateIds = uniqueStrings(rankedCards.map(c => String(c.id)));
+  const candidateSet = new Set(candidateIds);
+
+  // 1) Check WL PIPs first to confirm the 3 non-matched adoptees are still OFC.
+  const ofcTitlePredicate = (groupTitle: string) =>
+    groupTitle.trim().startsWith('OFC:');
+
+  const wlFound = await fetchCandidateIdsFromBoard({
+    boardId: wlBoardId,
+    candidateIds: candidateSet,
+    groupTitlePredicate: ofcTitlePredicate,
+    maxFound: 3,
+  });
+
+  // If 3 candidates exist in OFC, the remaining 4th is the matched one.
+  if (wlFound.size === 3) {
+    const matched = candidateIds.find(id => !wlFound.has(id));
+    if (!matched) {
+      throw new Error(
+        'Inconsistent state: wlFound size was 3 but no unmatched candidate found.',
+      );
+    }
+
+    const unmatchedAdopteeIds = candidateIds.filter(id => id !== matched);
+    return { matchedAdopteeId: matched, unmatchedAdopteeIds };
+  }
+
+  // 2) Fallback: check Adopted board for the matched adoptee.
+  const adoptedTitlePredicate = (groupTitle: string) => {
+    const t = groupTitle.trim();
+    return (
+      t.startsWith('A: Adopted') ||
+      t.startsWith('B: Adopted') ||
+      t.startsWith('AO: Adopted')
+    );
+  };
+
+  const adoptedFound = await fetchCandidateIdsFromBoard({
+    boardId: adoptedBoardId,
+    candidateIds: candidateSet,
+    groupTitlePredicate: adoptedTitlePredicate,
+    maxFound: 1,
+  });
+
+  if (adoptedFound.size !== 1) {
+    throw new Error(
+      `Could not uniquely determine matched adoptee. matchedFound=${Array.from(
+        adoptedFound,
+      ).join(
+        ',',
+      )} wlFound=${Array.from(wlFound).join(',')} candidates=${candidateIds.join(',')}`,
+    );
+  }
+
+  const matchedAdopteeId = Array.from(adoptedFound)[0];
+  const unmatchedAdopteeIds = candidateIds.filter(
+    id => id !== matchedAdopteeId,
+  );
+
+  return { matchedAdopteeId, unmatchedAdopteeIds };
+}

--- a/actions/queries/query.ts
+++ b/actions/queries/query.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { autoEmailSender } from '@/actions/emails/email';
 import { getSupabaseServerClient } from '@/lib/supabase';
 import { AdopteeMatch, AdopterApplicationUpdate } from '@/types/schema';
 
@@ -78,6 +79,33 @@ export async function upsertApplication(
 
   if (error)
     throw new Error(`Error upserting application data: ${error.message}`);
+
+  return data;
+}
+
+export async function submitApplication(
+  app: AdopterApplicationUpdate & {
+    adopter_uuid: string;
+    app_uuid: string;
+  },
+  adopterEmail: string,
+) {
+  if (!process.env.BREVO_SMTP_USER || !process.env.BREVO_SMTP_KEY) {
+    throw new Error(
+      'Missing email configuration: BREVO_SMTP_USER and BREVO_SMTP_KEY must be set in environment',
+    );
+  }
+
+  const data = await upsertApplication(app);
+
+  const text = `Hi!
+
+Thank you for submitting your adoption application (ID: ${app.app_uuid}). We'll review it and get back to you with a match soon.
+
+Best,
+The Adopt an Inmate Team`;
+
+  await autoEmailSender(text, 'Adoption Application Submitted', adopterEmail);
 
   return data;
 }

--- a/app/api/test/matchedAdoptee/route.ts
+++ b/app/api/test/matchedAdoptee/route.ts
@@ -1,0 +1,18 @@
+import { queryMatchedAdopteeForApprovedApplication } from '@/actions/monday/queryMatchedAdopteeForApprovedApplication';
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const applicationId = url.searchParams.get('applicationId') ?? '';
+
+  const result = await queryMatchedAdopteeForApprovedApplication(applicationId);
+
+  // Useful while manually testing with a fake/sandbox row.
+  console.log(
+    '[matchedAdoptee] applicationId=',
+    applicationId,
+    'result=',
+    result,
+  );
+
+  return Response.json(result);
+}

--- a/app/api/test/route.ts
+++ b/app/api/test/route.ts
@@ -5,6 +5,7 @@ export async function GET() {
     date_of_birth: new Date().toISOString().split('T')[0],
     first_name: 'First',
     last_name: 'Last',
+    monday_id: null,
     pronouns: 'he/him',
     state: 'California',
     user_id: 'asd',

--- a/components/application/matching/MatchingReviewScreen.tsx
+++ b/components/application/matching/MatchingReviewScreen.tsx
@@ -29,7 +29,7 @@ export default function MatchingReviewScreen({
       status: 'pending',
       ranked_cards: rankedMatches,
       time_submitted: new Date().toISOString(),
-    }); //new upsert helper
+    });
 
     advanceToStage(ApplicationStage.SUBMITTED);
     setIsLoading(false);

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,5 @@
+export const CONFIG = {
+  // If true, it will allow the server to issue Monday mutation
+  // calls. ONLY ENABLE IF THE CLIENT->SERVER API CALL IS SAFE FROM ATTACKS.
+  enableMondayMutations: false,
+};

--- a/hooks/app-process.ts
+++ b/hooks/app-process.ts
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import Logger from '@/actions/logging';
-import { upsertApplication } from '@/actions/queries/query';
+import { submitApplication } from '@/actions/queries/query';
 import { useApplicationContext } from '@/contexts/ApplicationContext';
 import { useAuth } from '@/contexts/AuthProvider';
 import { ApplicationStage } from '@/types/enums';
@@ -15,7 +15,7 @@ import { AdopterApplicationUpdate } from '@/types/schema';
 export const useApplicationNavigation = () => {
   const router = useRouter();
   const { appState, appStage } = useApplicationContext();
-  const { userId } = useAuth();
+  const { userId, userEmail } = useAuth();
 
   /**
    * Helper function to record current stage in context
@@ -36,11 +36,20 @@ export const useApplicationNavigation = () => {
         Logger.error('Updating Application Info: missing userId');
         return;
       }
-      await upsertApplication({
-        adopter_uuid: userId,
-        app_uuid: appState.appId,
-        ...app,
-      });
+      if (!userEmail) {
+        Logger.error(
+          `Updating Application Info: missing userEmail for userId ${userId}`,
+        );
+        return;
+      }
+      await submitApplication(
+        {
+          adopter_uuid: userId,
+          app_uuid: appState.appId,
+          ...app,
+        },
+        userEmail,
+      );
     } catch (error) {
       Logger.error(`Failed to save application: ${String(error)}`);
     }

--- a/hooks/onboarding.ts
+++ b/hooks/onboarding.ts
@@ -45,6 +45,7 @@ export const useSubmitOnboarding = () => {
       date_of_birth: info.dob.toUTCString(),
       first_name: info.firstName,
       last_name: info.lastName,
+      monday_id: null,
       pronouns: info.pronouns,
       state: info.state,
       veteran_status: info.isVeteran,

--- a/lib/supabase/service.ts
+++ b/lib/supabase/service.ts
@@ -1,0 +1,32 @@
+'use server';
+
+import { createClient } from '@supabase/supabase-js';
+import { Database } from '@/types/database.types';
+
+/**
+ * Creates a SERVICE Supabase Client, which
+ * bypasses security checks. ONLY USE THIS IF YOU
+ * KNOW WHAT YOU ARE DOING.
+ */
+export async function dangerous_getSupabaseServiceClient() {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.SUPABASE_SERVICE_KEY
+  ) {
+    throw new Error(
+      'No Supabase environment variables detected, please make sure they are in place!',
+    );
+  }
+
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_KEY,
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
+    },
+  );
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -63,10 +63,26 @@ export const sleep = async (ms: number) => {
 };
 
 /**
+ * Throw an error if the condition is false
+ * with an optionally provided error message.
+ */
+export const assert = (cond: boolean, msg?: unknown) => {
+  if (!cond) throw msg;
+};
+
+/**
  * Asserts that an environment variable exists.
  */
 export const assertEnvVarExists = (key: string) => {
   if (!process.env[key]) throw new Error(`Could not find ${key}, is it set?`);
+};
+
+/**
+ * Safely gets an environment variable. If it doesn't exist, throw an error.
+ */
+export const getEnvVar = (key: string) => {
+  assertEnvVarExists(key);
+  return process.env[key] as string;
 };
 
 /**

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -105,11 +105,14 @@ export type Database = {
           embedding: string | null
           facility: string | null
           first_name: string | null
+          formerly_adopted: boolean | null
           gender: string | null
           id: string
+          inmate_id: string
           last_name: string | null
           offense: string | null
           state: string | null
+          status: Database["public"]["Enums"]["adoptee_status"] | null
           veteran_status: string | null
         }
         Insert: {
@@ -119,11 +122,14 @@ export type Database = {
           embedding?: string | null
           facility?: string | null
           first_name?: string | null
+          formerly_adopted?: boolean | null
           gender?: string | null
           id: string
+          inmate_id: string
           last_name?: string | null
           offense?: string | null
           state?: string | null
+          status?: Database["public"]["Enums"]["adoptee_status"] | null
           veteran_status?: string | null
         }
         Update: {
@@ -133,11 +139,14 @@ export type Database = {
           embedding?: string | null
           facility?: string | null
           first_name?: string | null
+          formerly_adopted?: boolean | null
           gender?: string | null
           id?: string
+          inmate_id?: string
           last_name?: string | null
           offense?: string | null
           state?: string | null
+          status?: Database["public"]["Enums"]["adoptee_status"] | null
           veteran_status?: string | null
         }
         Relationships: []
@@ -146,7 +155,9 @@ export type Database = {
         Row: {
           adopter_uuid: string
           app_uuid: string
+          exported_to_monday: boolean
           gender_pref: string | null
+          monday_id: string | null
           offense_pref: string[] | null
           personal_bio: string | null
           ranked_cards: Json | null
@@ -157,7 +168,9 @@ export type Database = {
         Insert: {
           adopter_uuid: string
           app_uuid?: string
+          exported_to_monday?: boolean
           gender_pref?: string | null
+          monday_id?: string | null
           offense_pref?: string[] | null
           personal_bio?: string | null
           ranked_cards?: Json | null
@@ -168,7 +181,9 @@ export type Database = {
         Update: {
           adopter_uuid?: string
           app_uuid?: string
+          exported_to_monday?: boolean
           gender_pref?: string | null
+          monday_id?: string | null
           offense_pref?: string[] | null
           personal_bio?: string | null
           ranked_cards?: Json | null
@@ -191,6 +206,7 @@ export type Database = {
           date_of_birth: string
           first_name: string
           last_name: string
+          monday_id: string | null
           pronouns: string
           state: string
           user_id: string
@@ -200,6 +216,7 @@ export type Database = {
           date_of_birth: string
           first_name: string
           last_name: string
+          monday_id?: string | null
           pronouns: string
           state: string
           user_id?: string
@@ -209,6 +226,7 @@ export type Database = {
           date_of_birth?: string
           first_name?: string
           last_name?: string
+          monday_id?: string | null
           pronouns?: string
           state?: string
           user_id?: string
@@ -260,9 +278,27 @@ export type Database = {
           veteran_status: string
         }[]
       }
+      get_user_and_application: {
+        Args: { app_id: string }
+        Returns: {
+          adopter_monday_id: string | null
+          date_of_birth: string
+          exported_to_monday: boolean
+          first_name: string
+          gender_pref: string
+          last_name: string
+          personal_bio: string
+          pronouns: string
+          ranked_cards: string[]
+          state: string
+          user_id: string
+          veteran_status: boolean
+        }[]
+      }
       transfer_tables: { Args: never; Returns: undefined }
     }
     Enums: {
+      adoptee_status: "WAIT_LISTED" | "OUT_FOR_CONSIDERATION"
       status_vals: "incomplete" | "pending" | "accepted" | "rejected" | "ended"
     }
     CompositeTypes: {

--- a/types/schema.ts
+++ b/types/schema.ts
@@ -10,6 +10,9 @@ export type Profile = PublicTable<'adopter_profiles'>;
 // TODO: update table name when no longer in testing
 export type AdopterApplication = PublicTable<'adopter_applications_dummy'>;
 
+export type ProfileAndApplication =
+  PublicFunctions['get_user_and_application']['Returns'][number];
+
 export type AdopteeMatch =
   PublicFunctions['find_top_k_filtered']['Returns'][number];
 


### PR DESCRIPTION

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

The PR adds a reusable Monday mutation helper for updating adoptee statuses and wires exportApplication to use it for the OFC flow.

Added `actions/monday/mutations/changeStatus.ts` with `updateAdopteeMondayStatus(ids, status)`:

- status: "OFC" returns a GraphQL mutation fragment to set `status__1` to OFC: Out for Consideration (no execution).
- status: "WL" looks up formerly_adopted from `adoptee_vector_test`, maps each adoptee to either:

  - WLFA: Wait Listed Formerly Adopted, or
  - WL: Wait Listed, then executes the Monday mutation.

- Replaced `getQueryUpdateAdoptees` usage in `actions/monday/mutations/exportApplication.ts` with `updateAdopteeMondayStatus(..., "OFC").`
- Added minimal supporting type/util updates needed for the main-branch export flow compatibility (ProfileAndApplication, env helpers, related table fields).

## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

- Start with `actions/monday/mutations/changeStatus.ts`
- Confirm OFC path returns only mutation query text.
- Confirm WL path fetches `formerly_adopted` and executes Monday mutation with the correct label mapping.
- Review `actions/monday/mutations/exportApplication.ts`
- Verify OFC mutation generation now goes through `updateAdopteeMondayStatus(..., "OFC")`.
- Verify behavior remains unchanged otherwise (subitem creation + OFC updates in one combined mutation).

Skim support files for type alignment only:

- `types/schema.ts`
- `types/database.types.ts`
- `lib/utils.ts`
- small call-site updates in `actions/monday/mutation.ts`, `hooks/onboarding.ts`, `app/api/test/route.ts`.

Suggested test flows:
- Export application flow (OFC): confirm returned query fragment updates all ranked adoptee IDs to OFC: Out for Consideration.
- WL helper flow: call `updateAdopteeMondayStatus([...], "WL")` with mixed formerly_adopted rows and verify label per row is WLFA vs WL.
- Edge cases: empty ID array returns empty query; Supabase read failure in WL path throws explicit error.


CC: @InayaY3