### PR TITLE
[feat] Monday Adoptee Status Update Function

### DIFF
--- a/actions/monday/mutations/changeStatus.ts
+++ b/actions/monday/mutations/changeStatus.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import Logger from '@/actions/logging';
+import { CONFIG } from '@/config';
 import { dangerous_getSupabaseServiceClient } from '@/lib/supabase/service';
 import { assertEnvVarExists } from '@/lib/utils';
 import { mondayApiClient } from '../core';
@@ -17,7 +18,7 @@ export type UpdateAdopteeMondayStatusResult = {
   error: string | null;
 };
 
-const OFC_STATUS_LABEL = 'OFC: Out for Consideration';
+const OFC_STATUS_LABEL = 'OFC: Out For Consideration';
 const WL_STATUS_LABEL = 'WL: Wait Listed';
 const WLFA_STATUS_LABEL = 'WLFA: Wait Listed Formerly Adopted';
 
@@ -40,8 +41,8 @@ function buildStatusMutationFields(
 }
 
 type WaitListLabelsResult =
-  | { ok: true; statusLabelsById: Record<string, string> }
-  | { ok: false; message: string };
+  | { success: true; statusLabelsById: Record<string, string> }
+  | { success: false; message: string };
 
 //determine if adoptee is formerly adopted
 async function getWaitListStatusLabels(
@@ -55,7 +56,7 @@ async function getWaitListStatusLabels(
     Logger.error(
       `getWaitListStatusLabels: could not create Supabase service client: ${message}`,
     );
-    return { ok: false, message };
+    return { success: false, message };
   }
 
   const { data, error } = await supabaseService
@@ -67,7 +68,7 @@ async function getWaitListStatusLabels(
     Logger.error(
       `getWaitListStatusLabels: failed to fetch formerly_adopted: ${error.message}`,
     );
-    return { ok: false, message: error.message };
+    return { success: false, message: error.message };
   }
 
   //2 step process to avoid O(N^2) - faster lookup with Map
@@ -85,14 +86,18 @@ async function getWaitListStatusLabels(
     {} as Record<string, string>,
   );
 
-  return { ok: true, statusLabelsById };
+  return { success: true, statusLabelsById };
 }
 
 //main function
+//for OFC, will return the query
+//for WL, will make the change
 export async function updateAdopteeMondayStatus(
   adopteeMondayIds: string[],
   status: MondayAdopteeStatus,
 ): Promise<UpdateAdopteeMondayStatusResult> {
+  if (!CONFIG.enableMondayMutations)
+    return { data: '', error: 'Forbidden action.' };
   if (adopteeMondayIds.length === 0) {
     return { data: '', error: null };
   }
@@ -100,7 +105,7 @@ export async function updateAdopteeMondayStatus(
   let statusLabelsById: Record<string, string>;
   if (status === 'WL') {
     const wlLabels = await getWaitListStatusLabels(adopteeMondayIds);
-    if (!wlLabels.ok) {
+    if (!wlLabels.success) {
       Logger.error(
         `updateAdopteeMondayStatus(WL): skipping Monday update for ids [${adopteeMondayIds.join(', ')}]: ${wlLabels.message}`,
       );

--- a/actions/monday/mutations/changeStatus.ts
+++ b/actions/monday/mutations/changeStatus.ts
@@ -11,7 +11,7 @@ const MONDAY_WL_PIPS_BOARD_ID = process.env.MONDAY_WL_PIPS_BOARD_ID ?? ''; //sto
 
 export type MondayAdopteeStatus = 'WL' | 'OFC'; //restricts to 2 values
 
-//as other server 
+//as other server
 export type UpdateAdopteeMondayStatusResult = {
   data: string | null;
   error: string | null;
@@ -96,7 +96,6 @@ export async function updateAdopteeMondayStatus(
   if (adopteeMondayIds.length === 0) {
     return { data: '', error: null };
   }
-
 
   let statusLabelsById: Record<string, string>;
   if (status === 'WL') {

--- a/actions/monday/mutations/changeStatus.ts
+++ b/actions/monday/mutations/changeStatus.ts
@@ -1,0 +1,106 @@
+'use server';
+
+import Logger from '@/actions/logging';
+import { dangerous_getSupabaseServiceClient } from '@/lib/supabase/service';
+import { assertEnvVarExists } from '@/lib/utils';
+import { mondayApiClient } from '../core';
+
+assertEnvVarExists('MONDAY_WL_PIPS_BOARD_ID');
+
+const MONDAY_WL_PIPS_BOARD_ID = process.env.MONDAY_WL_PIPS_BOARD_ID ?? ''; //store env var
+
+export type MondayAdopteeStatus = 'WL' | 'OFC'; //restricts to 2 values
+
+const OFC_STATUS_LABEL = 'OFC: Out for Consideration';
+const WL_STATUS_LABEL = 'WL: Wait Listed';
+const WLFA_STATUS_LABEL = 'WLFA: Wait Listed Formerly Adopted';
+
+//build mutation operations
+function buildStatusMutationFields(
+  adopteeMondayIds: string[],
+  statusLabelsById: Record<string, string>,
+) {
+  return adopteeMondayIds
+    .map((id, idx) => {
+      const value = statusLabelsById[id];
+      return `update${idx + 1}:change_simple_column_value(
+        board_id: "${MONDAY_WL_PIPS_BOARD_ID}",
+        item_id: "${id}",
+        column_id: "status__1",
+        value: "${value}"
+      ) { id }`;
+    })
+    .join(',');
+}
+
+//determine if adoptee is formerly adopted
+async function getWaitListStatusLabels(adopteeMondayIds: string[]) {
+  const supabaseService = await dangerous_getSupabaseServiceClient();
+  const { data, error } = await supabaseService
+    .from('adoptee_vector_test')
+    .select('id, formerly_adopted')
+    .in('id', adopteeMondayIds);
+
+  if (error) {
+    //if no ids
+    throw new Error(`Failed to fetch formerly_adopted flags: ${error.message}`);
+  }
+
+  //2 step process to avoid O(N^2) - faster lookup with Map
+  const formerlyAdoptedById = new Map(
+    (data ?? []).map(row => [String(row.id), Boolean(row.formerly_adopted)]),
+  );
+
+  return adopteeMondayIds.reduce(
+    (acc, id) => {
+      acc[id] = formerlyAdoptedById.get(id)
+        ? WLFA_STATUS_LABEL
+        : WL_STATUS_LABEL;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+}
+
+//main function
+export async function updateAdopteeMondayStatus(
+  adopteeMondayIds: string[],
+  status: MondayAdopteeStatus,
+) {
+  if (adopteeMondayIds.length === 0) return '';
+
+  const uniqueAdopteeMondayIds = Array.from(adopteeMondayIds);
+
+  const statusLabelsById =
+    status === 'WL'
+      ? await getWaitListStatusLabels(uniqueAdopteeMondayIds)
+      : Object.fromEntries(
+          //for not string string
+          uniqueAdopteeMondayIds.map(id => [id, OFC_STATUS_LABEL]),
+        );
+
+  const mutationFields = buildStatusMutationFields(
+    uniqueAdopteeMondayIds,
+    statusLabelsById,
+  );
+
+  //only run if WL to avoid extra queries
+  if (status === 'WL') {
+    const mutationQuery = ` 
+      mutation {
+        ${mutationFields}
+      }
+    `;
+
+    try {
+      await mondayApiClient.request(mutationQuery);
+    } catch (error) {
+      Logger.error(
+        `Failed to update adoptee Monday status to WL for ids ${uniqueAdopteeMondayIds.join(',')}: ${error}`,
+      );
+      throw error;
+    }
+  }
+
+  return mutationFields;
+}

--- a/actions/monday/mutations/changeStatus.ts
+++ b/actions/monday/mutations/changeStatus.ts
@@ -11,6 +11,12 @@ const MONDAY_WL_PIPS_BOARD_ID = process.env.MONDAY_WL_PIPS_BOARD_ID ?? ''; //sto
 
 export type MondayAdopteeStatus = 'WL' | 'OFC'; //restricts to 2 values
 
+//as other server 
+export type UpdateAdopteeMondayStatusResult = {
+  data: string | null;
+  error: string | null;
+};
+
 const OFC_STATUS_LABEL = 'OFC: Out for Consideration';
 const WL_STATUS_LABEL = 'WL: Wait Listed';
 const WLFA_STATUS_LABEL = 'WLFA: Wait Listed Formerly Adopted';
@@ -33,17 +39,35 @@ function buildStatusMutationFields(
     .join(',');
 }
 
+type WaitListLabelsResult =
+  | { ok: true; statusLabelsById: Record<string, string> }
+  | { ok: false; message: string };
+
 //determine if adoptee is formerly adopted
-async function getWaitListStatusLabels(adopteeMondayIds: string[]) {
-  const supabaseService = await dangerous_getSupabaseServiceClient();
+async function getWaitListStatusLabels(
+  adopteeMondayIds: string[],
+): Promise<WaitListLabelsResult> {
+  let supabaseService;
+  try {
+    supabaseService = await dangerous_getSupabaseServiceClient();
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    Logger.error(
+      `getWaitListStatusLabels: could not create Supabase service client: ${message}`,
+    );
+    return { ok: false, message };
+  }
+
   const { data, error } = await supabaseService
     .from('adoptee_vector_test')
     .select('id, formerly_adopted')
     .in('id', adopteeMondayIds);
 
   if (error) {
-    //if no ids
-    throw new Error(`Failed to fetch formerly_adopted flags: ${error.message}`);
+    Logger.error(
+      `getWaitListStatusLabels: failed to fetch formerly_adopted: ${error.message}`,
+    );
+    return { ok: false, message: error.message };
   }
 
   //2 step process to avoid O(N^2) - faster lookup with Map
@@ -51,7 +75,7 @@ async function getWaitListStatusLabels(adopteeMondayIds: string[]) {
     (data ?? []).map(row => [String(row.id), Boolean(row.formerly_adopted)]),
   );
 
-  return adopteeMondayIds.reduce(
+  const statusLabelsById = adopteeMondayIds.reduce(
     (acc, id) => {
       acc[id] = formerlyAdoptedById.get(id)
         ? WLFA_STATUS_LABEL
@@ -60,27 +84,41 @@ async function getWaitListStatusLabels(adopteeMondayIds: string[]) {
     },
     {} as Record<string, string>,
   );
+
+  return { ok: true, statusLabelsById };
 }
 
 //main function
 export async function updateAdopteeMondayStatus(
   adopteeMondayIds: string[],
   status: MondayAdopteeStatus,
-) {
-  if (adopteeMondayIds.length === 0) return '';
+): Promise<UpdateAdopteeMondayStatusResult> {
+  if (adopteeMondayIds.length === 0) {
+    return { data: '', error: null };
+  }
 
-  const uniqueAdopteeMondayIds = Array.from(adopteeMondayIds);
 
-  const statusLabelsById =
-    status === 'WL'
-      ? await getWaitListStatusLabels(uniqueAdopteeMondayIds)
-      : Object.fromEntries(
-          //for not string string
-          uniqueAdopteeMondayIds.map(id => [id, OFC_STATUS_LABEL]),
-        );
+  let statusLabelsById: Record<string, string>;
+  if (status === 'WL') {
+    const wlLabels = await getWaitListStatusLabels(adopteeMondayIds);
+    if (!wlLabels.ok) {
+      Logger.error(
+        `updateAdopteeMondayStatus(WL): skipping Monday update for ids [${adopteeMondayIds.join(', ')}]: ${wlLabels.message}`,
+      );
+      return {
+        data: null,
+        error: 'An unexpected error occurred.',
+      };
+    }
+    statusLabelsById = wlLabels.statusLabelsById;
+  } else {
+    statusLabelsById = Object.fromEntries(
+      adopteeMondayIds.map(id => [id, OFC_STATUS_LABEL]),
+    );
+  }
 
   const mutationFields = buildStatusMutationFields(
-    uniqueAdopteeMondayIds,
+    adopteeMondayIds,
     statusLabelsById,
   );
 
@@ -96,11 +134,14 @@ export async function updateAdopteeMondayStatus(
       await mondayApiClient.request(mutationQuery);
     } catch (error) {
       Logger.error(
-        `Failed to update adoptee Monday status to WL for ids ${uniqueAdopteeMondayIds.join(',')}: ${error}`,
+        `Failed to update adoptee Monday status to WL for ids ${adopteeMondayIds.join(',')}: ${error}`,
       );
-      throw error;
+      return {
+        data: null,
+        error: 'An unexpected error occurred.',
+      };
     }
   }
 
-  return mutationFields;
+  return { data: mutationFields, error: null };
 }

--- a/actions/monday/mutations/exportApplication.ts
+++ b/actions/monday/mutations/exportApplication.ts
@@ -316,9 +316,6 @@ const exportApplication = async (appId: string) => {
       Logger.error(
         `[CRITICAL] Error trying to update adopter profile for user ${user.email} (ID ${user.id}): ${updateError}`,
       );
-      // NOTE: allow pass through, don't want to report unsuccessful just
-      // bc push to supabase fails. Should still aim to get data to Monday.
-      // Then, admins can at least have access to data present here.
     }
   }
 
@@ -330,10 +327,23 @@ const exportApplication = async (appId: string) => {
     mainItemId,
     adopteeData,
   );
-  const updateAdopteesQuery = await updateAdopteeMondayStatus(
+  const {
+    data: updateAdopteesQuery,
+    error: updateAdopteesFieldsError,
+  } = await updateAdopteeMondayStatus(
     appData.ranked_cards as Array<string>,
     'OFC',
   );
+
+  if (updateAdopteesFieldsError || updateAdopteesQuery === null) {
+    Logger.error(
+      `exportApplication: could not build Monday OFC status fields for app ${appId}: ${updateAdopteesFieldsError ?? 'null data'}`,
+    );
+    return {
+      success: false,
+      error: updateAdopteesFieldsError ?? 'An unexpected error occurred.',
+    };
+  }
 
   const supplementaryQuery = `
     mutation {
@@ -361,15 +371,11 @@ const exportApplication = async (appId: string) => {
     .update({ exported_to_monday: true, monday_id: subitemId })
     .eq('app_uuid', appId);
 
-  // highly unlikely
   // would only error if app was deleted
   // or columns were renamed/deleted
   if (updateError) {
     Logger.error(`[CRITICAL] Error trying to update ${appId}: ${updateError}`);
-    // NOTE: allow successful report to go through, since at least
-    // the data reached the admins. If the push fails once,
-    // chances are, it will fail again - the cause is likely permanent
-    // and should be critical cause to investigate.
+    
   }
 
   // mark adoptees as OFC on Supabase

--- a/actions/monday/mutations/exportApplication.ts
+++ b/actions/monday/mutations/exportApplication.ts
@@ -373,7 +373,6 @@ const exportApplication = async (appId: string) => {
   // or columns were renamed/deleted
   if (updateError) {
     Logger.error(`[CRITICAL] Error trying to update ${appId}: ${updateError}`);
-    
   }
 
   // mark adoptees as OFC on Supabase

--- a/actions/monday/mutations/exportApplication.ts
+++ b/actions/monday/mutations/exportApplication.ts
@@ -9,6 +9,7 @@ import { dangerous_getSupabaseServiceClient } from '@/lib/supabase/service';
 import { assert, getEnvVar } from '@/lib/utils';
 import { ProfileAndApplication } from '@/types/schema';
 import { mondayApiClient } from '../core';
+import { updateAdopteeMondayStatus } from './changeStatus';
 
 // get env var and assert it exists at system level to trigger
 // error messages at build time (rather than run time)
@@ -17,7 +18,6 @@ const MONDAY_ADOPTER_DATA_BOARD_ID = getEnvVar('MONDAY_ADOPTER_DATA_BOARD_ID');
 const MONDAY_ADOPTER_DATA_WAITING_GROUP_ID = getEnvVar(
   'MONDAY_ADOPTER_DATA_WAITING_GROUP_ID',
 );
-const MONDAY_WL_PIPS_BOARD_ID = getEnvVar('MONDAY_WL_PIPS_BOARD_ID');
 
 ////
 // HELPER FUNCTION
@@ -97,28 +97,6 @@ const parseColumns = <K extends string>(
     },
     {},
   );
-};
-
-/**
- * Generate a query to update the status
- * of relevant adoptee rows in the WL PIPs board
- * to OFC: Out For Consideration.
- */
-const getQueryUpdateAdoptees = (appData: ProfileAndApplication) => {
-  const rankedCards = appData.ranked_cards as Array<string>;
-  const adopteeUpdatesQueries = rankedCards.map(
-    (id, idx) =>
-      `update${idx + 1}:change_simple_column_value(
-          board_id: "${MONDAY_WL_PIPS_BOARD_ID}",
-          item_id: "${id}",
-          column_id: "status__1",
-          value: "OFC: Out For Consideration"
-        ) { id }`,
-  );
-
-  const adopteeUpdatesQuery = adopteeUpdatesQueries.join(',');
-
-  return adopteeUpdatesQuery;
 };
 
 /**
@@ -352,7 +330,10 @@ const exportApplication = async (appId: string) => {
     mainItemId,
     adopteeData,
   );
-  const updateAdopteesQuery = getQueryUpdateAdoptees(appData);
+  const updateAdopteesQuery = await updateAdopteeMondayStatus(
+    appData.ranked_cards as Array<string>,
+    'OFC',
+  );
 
   const supplementaryQuery = `
     mutation {

--- a/actions/monday/mutations/exportApplication.ts
+++ b/actions/monday/mutations/exportApplication.ts
@@ -327,13 +327,11 @@ const exportApplication = async (appId: string) => {
     mainItemId,
     adopteeData,
   );
-  const {
-    data: updateAdopteesQuery,
-    error: updateAdopteesFieldsError,
-  } = await updateAdopteeMondayStatus(
-    appData.ranked_cards as Array<string>,
-    'OFC',
-  );
+  const { data: updateAdopteesQuery, error: updateAdopteesFieldsError } =
+    await updateAdopteeMondayStatus(
+      appData.ranked_cards as Array<string>,
+      'OFC',
+    );
 
   if (updateAdopteesFieldsError || updateAdopteesQuery === null) {
     Logger.error(

--- a/actions/monday/mutations/exportApplication.ts
+++ b/actions/monday/mutations/exportApplication.ts
@@ -316,6 +316,9 @@ const exportApplication = async (appId: string) => {
       Logger.error(
         `[CRITICAL] Error trying to update adopter profile for user ${user.email} (ID ${user.id}): ${updateError}`,
       );
+      // NOTE: allow pass through, don't want to report unsuccessful just
+      // bc push to supabase fails. Should still aim to get data to Monday.
+      // Then, admins can at least have access to data present here.
     }
   }
 
@@ -373,6 +376,10 @@ const exportApplication = async (appId: string) => {
   // or columns were renamed/deleted
   if (updateError) {
     Logger.error(`[CRITICAL] Error trying to update ${appId}: ${updateError}`);
+    // NOTE: allow successful report to go through, since at least
+    // the data reached the admins. If the push fails once,
+    // chances are, it will fail again - the cause is likely permanent
+    // and should be critical cause to investigate.
   }
 
   // mark adoptees as OFC on Supabase

--- a/app/api/test/update-adoptee-status/route.ts
+++ b/app/api/test/update-adoptee-status/route.ts
@@ -1,0 +1,40 @@
+// import Logger from '@/actions/logging';
+// import { mondayApiClient } from '@/actions/monday/core';
+// import { updateAdopteeMondayStatus } from '@/actions/monday/mutations/changeStatus';
+
+export async function GET() {
+  return new Response('Forbidden');
+
+  // const ids = ['']; //set to 4 or less adoptee (monday) IDs
+  // const status = 'WL'; //set to WL or OFC, and uncomment if block for OFC
+
+  // const result = await updateAdopteeMondayStatus(ids, status);
+
+  // console.log('[test:updateAdopteeMondayStatus]', {
+  //   ids,
+  //   status,
+  //   result,
+  // });
+
+  // if (status === 'OFC') {
+  //   //since only WL makes the actual change
+  //   try {
+  //     const query = `
+  //       mutation {
+  //         ${result.data}
+  //       }
+  //     `;
+  //     await mondayApiClient.request(query);
+  //   } catch (error) {
+  //     Logger.error(
+  //       `Failed to update adoptee Monday status to WL for ids ${ids.join(',')}: ${error}`,
+  //     );
+  //     return Response.json(
+  //       { data: null, error: 'An unexpected error occurred.' },
+  //       { status: 500 },
+  //     );
+  //   }
+  // }
+
+  // return Response.json(result);
+}


### PR DESCRIPTION
[//]: # "Feel free to customize this template and the emojis to your project's vibes"

## What's new in this PR
### Description

Adds a Monday.com helper in `actions/monday/mutations/changeStatus.ts` to update Adoptee status. 

- if status == 'OFC': no change is made
- if status == 'WL' reads from Supabase to map the id to 'WLFA' or 'WL'

Replaces the old helper in `exportApplication.ts` with `updateAdopteeMondayStatus`


## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

1. Look at `actions/monday/mutations/changeStatus.ts` for mutation behavior, Supabase query, and error handling.
2. Check `actions/monday/mutations/exportApplication.ts` for updated call.


